### PR TITLE
Bump commons-io

### DIFF
--- a/lab-11-spring-data-redis/lab-07-spring-data-redis-with-redisson/pom.xml
+++ b/lab-11-spring-data-redis/lab-07-spring-data-redis-with-redisson/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

---
updated-dependencies:
- dependency-name: commons-io:commons-io
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>